### PR TITLE
Updated default address to dishy.starlink.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Currently, the following metrics are exposed:
 Configuration happens via the following env vars:
 
 - `BIND_ADDRESS`: Host and port to bind the HTTP server to. Defaults to `0.0.0.0:9184`.
-- `STARLINK_ADDRESS`: Protocol, host and port of the Starlink dish. Defaults to `http://192.168.100.1:9200`.
+- `STARLINK_ADDRESS`: Protocol, host and port of the Starlink dish. Defaults to `http://dishy.starlink.com:9200`.
 
 ### Local
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Configuration happens via the following env vars:
 ### Docker
 
     docker build -t ghcr.io/ewilken/starlink-exporter .
-    docker run --net=host ghcr.io/ewilken/starlink-exporter
+    docker run ghcr.io/ewilken/starlink-exporter
 
 ### Kubernetes
 
@@ -102,8 +102,7 @@ spec:
             - name: BIND_ADDRESS
               value: '0.0.0.0:9184'
             - name: STARLINK_ADDRESS
-              value: 'http://192.168.100.1:9200'
-      hostNetwork: true
+              value: 'http://dishy.starlink.com:9200'
       dnsPolicy: ClusterFirstWithHostNet
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Error> {
         .unwrap_or("0.0.0.0:9184".to_string())
         .parse::<SocketAddr>()
         .expect("parsing BIND_ADDRESS");
-    let starlink_address = dotenv::var("STARLINK_ADDRESS").unwrap_or("http://192.168.100.1:9200".to_string());
+    let starlink_address = dotenv::var("STARLINK_ADDRESS").unwrap_or("http://dishy.starlink.com:9200".to_string());
 
     info!("connecting ro Starlink device on {}", &starlink_address);
 


### PR DESCRIPTION
Changed default address to hostname "dishy.starlink.com" which is automatically resolved to its IP address.
In that way we can use docker network instead of host network type.

Compiled locally and it worked fine, so should be good enough.

Thanks!
Closes #2 
